### PR TITLE
Automatic classification: prefer taxon with "ACCEPTED"

### DIFF
--- a/R/get_classification.R
+++ b/R/get_classification.R
@@ -27,7 +27,7 @@
 #' get_classification("Homo sapiens")
 #' get_classification(c("Canis lupus", "Felis catus"))
 #' get_classification("Pikachu")
-#' @seealso 
+#' @seealso
 #' [get_classification_buk], [taxize::resolve], [taxize::classification]
 get_classification <- function(
     taxon,
@@ -174,7 +174,16 @@ get_classification <- function(
     data_taxon_mached_name_id_full <-
       taxon_mached_name_id_check %>%
       purrr::map(
-        .f = ~ dplyr::slice(.x, 1)
+        .f = ~ {
+          if (
+            "ACCEPTED" %in% .x$status
+          ) {
+            dplyr::filter(.x, status == "ACCEPTED") %>%
+              dplyr::slice(1)
+          } else {
+            dplyr::slice(.x, 1)
+          }
+        }
       ) %>%
       dplyr::bind_rows(
         .id = "matched_name"

--- a/R/get_classification_bulk.R
+++ b/R/get_classification_bulk.R
@@ -103,7 +103,16 @@ get_classification_buk <- function(
   data_taxa_mached_name_id_full <-
     taxa_mached_name_id_check %>%
     purrr::map(
-      .f = ~ dplyr::slice(.x, 1)
+      .f = ~ {
+        if (
+          "ACCEPTED" %in% .x$status
+        ) {
+          dplyr::filter(.x, status == "ACCEPTED") %>%
+            dplyr::slice(1)
+        } else {
+          dplyr::slice(.x, 1)
+        }
+      }
     ) %>%
     dplyr::bind_rows(
       .id = "matched_name"

--- a/tests/testthat/test-get_classification.R
+++ b/tests/testthat/test-get_classification.R
@@ -13,9 +13,16 @@ testthat::test_that("get_classification returns the correct classification", {
   testthat::expect_true(nrow(result2$classification) > 0)
   testthat::expect_equal(nrow(result2$classification), 6)
 
-  # Test case 3: Test with a nonexistent taxonomic name
-  result3 <- get_classification("Pikachu", interactive = FALSE)
-  testthat::expect_true(nrow(result3$data_resolve) == 0)
-  testthat::expect_true(nrow(result3$classification) == 0)
-  testthat::expect_identical(result3$id, NA_character_)
+  # Test case 3: Test with a partial species name
+  result3 <- get_classification("Felis Catus", interactive = FALSE)
+  testthat::expect_equal(result3$db, "gbif")
+  testthat::expect_equal(result3$id, "2435022")
+  testthat::expect_true(nrow(result3$classification) > 0)
+  testthat::expect_equal(nrow(result3$classification), 6)
+
+  # Test case 4: Test with a nonexistent taxonomic name
+  result4 <- get_classification("Pikachu", interactive = FALSE)
+  testthat::expect_true(nrow(result4$data_resolve) == 0)
+  testthat::expect_true(nrow(result4$classification) == 0)
+  testthat::expect_identical(result4$id, NA_character_)
 })


### PR DESCRIPTION
In the automatic selection of names, the first row was selected automatically. However, it is better to first selected "ACCEPTED" and the by the order.